### PR TITLE
Fix missing lubridate import

### DIFF
--- a/code/r/3_canton_weather_data_prepare.R
+++ b/code/r/3_canton_weather_data_prepare.R
@@ -28,6 +28,7 @@ library(haven)
 library(stringr)
 library(readr)
 library(tidyr)
+library(lubridate)
 
 # Loading shapefile -----------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- call `library(lubridate)` in the data prep script so `year()` is available

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_688528308aa8832db9cd18b5e16ff30c